### PR TITLE
Bump es6-module-transpiler version to ~0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "event-stream": "*",
-    "es6-module-transpiler": "~0.4.0"
+    "es6-module-transpiler": "~0.6.0"
   },
   "devDependencies": {
     "mocha": "~1.14.0",


### PR DESCRIPTION
Bumps the transpiler version to 0.6 to keep dependencies up to date.
Output of `npm run test`:

```
npm run test

> gulp-es6-module-transpiler@0.1.1 test /Users/aesthaddicts/Development/gulp-es6-module-transpiler
> mocha


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  40 passing (30ms)
```
