### PR TITLE
Update package.json repo URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rkusa/gulp-es6-module-transpiler/issues"
+    "url": "https://github.com/ryanseddon/gulp-es6-module-transpiler/issues"
   },
-  "homepage": "https://github.com/rkusa/gulp-es6-module-transpiler",
+  "homepage": "https://github.com/ryanseddon/gulp-es6-module-transpiler",
   "repository": {
     "type": "git",
-    "url": "git@github.com:rkusa/gulp-es6-module-transpiler.git"
+    "url": "git@github.com:ryanseddon/gulp-es6-module-transpiler.git"
   },
   "dependencies": {
     "es6-module-transpiler": "^0.9.6",


### PR DESCRIPTION
I think we should update the repo URLs in the `package.json`, shouldn't we?