### PR TITLE
Update es6-module-transpiler to 0.10.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,11 +93,8 @@ module.exports = exports = function(options) {
 
             callback();
         } catch(error) {
-            if (error.message && error.message.indexOf('missing module import') > -1) {
-                throw new Error(error.message + '. Looking in: ' + JSON.stringify(importPaths));
-            }
-
-            return callback(error);
+            var pluginError = new gutil.PluginError('gulp-es6-module-transpiler', error);
+            return callback(pluginError);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "git@github.com:ryanseddon/gulp-es6-module-transpiler.git"
   },
   "dependencies": {
-    "es6-module-transpiler": "^0.9.6",
+    "es6-module-transpiler": "^0.10.0",
     "gulp-util": "^3.0.1",
     "through2": "^0.6.1",
     "vinyl-sourcemaps-apply": "^0.1.1"


### PR DESCRIPTION
The old 0.9.6 version cannot import files with custom extensions like .es6