### PR TITLE
Replace `throw new Error` with PluginError. Update es6-module-transpiler to 0.10.0.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,10 @@ module.exports = exports = function(options) {
             callback();
         } catch(error) {
             if (error.message && error.message.indexOf('missing module import') > -1) {
-                throw new Error(error.message + '. Looking in: ' + JSON.stringify(importPaths));
+                return callback(new gutil.PluginError(
+                    'gulp-es6-module-transpiler',
+                    error.message + '. Looking in: ' + JSON.stringify(importPaths)
+                ));
             }
 
             return callback(error);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "git@github.com:ryanseddon/gulp-es6-module-transpiler.git"
   },
   "dependencies": {
-    "es6-module-transpiler": "^0.9.6",
+    "es6-module-transpiler": "^0.10.0",
     "gulp-util": "^3.0.1",
     "through2": "^0.6.1",
     "vinyl-sourcemaps-apply": "^0.1.1"

--- a/test/index.js
+++ b/test/index.js
@@ -282,15 +282,18 @@ describe('gulp-es6-module-transpiler', function() {
     describe('conversion', function() {
         describe('error', function() {
             it('should append importPaths if "missing module import" error was thrown', function() {
-                expect(function() {
-                    transpile({
-                        sources: [inputs.importAlt],
-                        basePath: inputDir
-                    }, function() {});
-                }.bind(this)).to.throwError(new RegExp(
-                    'missing module import from importAlt.js for path: bar.' +
-                    ' Looking in: \\["' + inputDir + '"\\]'
-                ));
+                transpile({
+                    sources: [inputs.importAlt],
+                    basePath: inputDir
+                }, function(error) {
+                    // Windows compatibility
+                    var inputDirRegex = inputDir.replace(/\\/g, '\\\\\\\\');
+
+                    expect(error.message).to.match(new RegExp(
+                        'missing module import from importAlt.js for path: bar.' +
+                        ' Looking in: \\["' + inputDirRegex + '"\\]'
+                    ));
+                });
             });
         });
 


### PR DESCRIPTION
Replacing `throw new Error` with PluginError allows catching errors outside without breaking gulp.watch().

The old 0.9.6 version of es6-module-transpiler cannot import files with custom extensions like .es6.