### PR TITLE
Removed dirtyness which led to a require error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,10 +7,7 @@ var sourceMap  = require('vinyl-sourcemaps-apply');
 var transpiler = require('es6-module-transpiler');
 var path       = require('path');
 
-// this is dirty, I know - however, installing an own version
-// of reacast can lead to errors because of gulp-es6mt and
-// es6-module-transpiler using different instances of recast
-var recast     = require('es6-module-transpiler/node_modules/recast');
+var recast     = require('recast');
 
 var FileResolver = transpiler.FileResolver;
 


### PR DESCRIPTION
`Error: Cannot find module 'es6-module-transpiler/node_modules/recast'`

I fixed by requiring the module recast without the es6-module-transpiler path and haven't found any problem at all.
Was it really necessary to bind the module to the local path? And what about using `__dirname` or any package.json trick?